### PR TITLE
fix adding zero-value shortcut issue

### DIFF
--- a/src/trie_tree.rs
+++ b/src/trie_tree.rs
@@ -172,7 +172,7 @@ impl<H: Hasher + Default, V: Value, S: StoreReadOps<V> + StoreWriteOps<V>>
                     }
                     _ => {
                         if target.is_zero() || last_height == 0 {
-                            let insert_value = if last_height == 0 {
+                            let insert_value = if last_height == 0 || node.is_zero() {
                                 node
                             } else {
                                 MergeValue::shortcut(key, node.hash::<H>(), last_height)


### PR DESCRIPTION
This PR fix an error if statement on update insertion when leaf's value is zero, may add a zero value shortcut into the store which is ill-formed